### PR TITLE
wrap jupyter with xvfb-run to allow off-screen rendering

### DIFF
--- a/ML_class/Dockerfile
+++ b/ML_class/Dockerfile
@@ -1,9 +1,9 @@
 FROM sachinruk/ds_base
 
-RUN apt-get update && apt-get install -y graphviz
+RUN apt-get update && apt-get install -y graphviz xvfb python-opengl
 RUN pip install graphviz xgboost
 
 VOLUME /notebook
 WORKDIR /notebook
 EXPOSE 8888
-CMD jupyter notebook --allow-root --no-browser --ip=0.0.0.0 --NotebookApp.token=
+CMD xvfb-run -s "-screen 0 1400x900x24" jupyter notebook --allow-root --no-browser --ip=0.0.0.0 --NotebookApp.token=


### PR DESCRIPTION
1400x900 is arbitrary.

Inside the container when running:

```
root@2e4d030ba5f3:/notebook# ps fax
  PID TTY      STAT   TIME COMMAND
   30 pts/0    Ss     0:00 bash
   40 pts/0    R+     0:00  \_ ps fax
    1 ?        Ss     0:00 /bin/sh -c xvfb-run -s "-screen 0 1400x900x24" jupyter notebook --allow-root --no-browser --ip=0.0.0.0 --NotebookApp.token=
    7 ?        S      0:00 /bin/sh /usr/bin/xvfb-run -s -screen 0 1400x900x24 jupyter notebook --allow-root --no-browser --ip=0.0.0.0 --NotebookApp.token=
   18 ?        Sl     0:00  \_ Xvfb :99 -screen 0 1400x900x24 -nolisten tcp -auth /tmp/xvfb-run.HsLIQI/Xauthority
   25 ?        S      0:01  \_ /root/miniconda3/bin/python /root/miniconda3/bin/jupyter-notebook --allow-root --no-browser --ip=0.0.0.0 --NotebookApp.token=
```